### PR TITLE
Only include Google Analytics tracking code in production

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-63919776-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-63919776-1');
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -37,13 +37,8 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.8/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-63919776-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+    {% if jekyll.environment == 'production' %}
+      {% include analytics.html %}
+    {% endif %}
 
-      gtag('config', 'UA-63919776-1');
-    </script>
   </head>


### PR DESCRIPTION
I split out the Google Analytics code to its own include-file that is only included when the environment is set to `production`.

GitHub Pages automatically builds the site with `JEKYLL_ENV=production`. I tested this with the following build command to mimick this behavior: `JEKYLL_ENV=production jekyll build` where it was included, while `jekyll build` didn't include it. Just as expected.

This was helpful: https://desiredpersona.com/google-analytics-jekyll/