### PR TITLE
Privately hosted section simplified to avoid misunderstandings

### DIFF
--- a/collections/_cms/index.md
+++ b/collections/_cms/index.md
@@ -130,7 +130,7 @@ To get started using the IndoorView feature for your Locations, please make sure
 |Android SDK|No|No|
 |iOS SDK|No|No|
 
-IndoorView only supports publicly available Google Street View imagery. If you will like to know more about privately hosted panorama images please see [Googles Custom Street View documentation](https://developers.google.com/maps/documentation/javascript/streetview#CustomStreetView).
+IndoorView only supports **publicly** available Google Street View imagery. If you would like to know more about **privately** hosted panorama images, please see [Googles Custom Street View documentation](https://developers.google.com/maps/documentation/javascript/streetview#CustomStreetView).
 
 **Developing your own app**
 

--- a/collections/_cms/index.md
+++ b/collections/_cms/index.md
@@ -130,6 +130,8 @@ To get started using the IndoorView feature for your Locations, please make sure
 |Android SDK|No|No|
 |iOS SDK|No|No|
 
+IndoorView only supports publicly available Google Street View imagery. If you will like to know more about privately hosted panorama images please see [Googles Custom Street View documentation](https://developers.google.com/maps/documentation/javascript/streetview#CustomStreetView).
+
 **Developing your own app**
 
 When developing your own app, you can still use the MapsIndoors CMS to save the Google Street View image information to a Location. When the Panorama image is set, the Location gets populated with a `streetViewConfig` property. Please see below for an example.
@@ -173,19 +175,6 @@ function initStreetView(streetViewConfig) {
 ```
 
 Please see the official [Google Street View Service documentation](https://developers.google.com/maps/documentation/javascript/streetview) for more information.
-
-**Privately hosted**
-
-As mentioned above, the IndoorView feature only supports publicly available Google Street View imagery but [in the Custom Street View documentation](https://developers.google.com/maps/documentation/javascript/streetview#CustomStreetView) you will find some well-written instructions on how to get up and running with your privately hosted panorama images and the Street View Service for the JavaScript API. At the moment, this is not supported in the Google Maps SDKs for iOS and Android.
-
-When the photographer is done all the panorama file names should include a `panoramaId`, `zoom`, `tileX` and `tileY` property, and the panorama can be called from the server like below. Please see the [sample link](https://developers.google.com/maps/documentation/javascript/examples/streetview-custom-simple) for much more information on this.
-
-```javascript
-function getCustomPanoramaTileUrl(panoId, zoom, tileX, tileY) {
-        return 'https://company/panorama/'
-            + panoId + '-' + zoom + '-' + tileX + '-' + tileY + '.jpg';
-}
-```
 
 ### Under "Show advanced"
 


### PR DESCRIPTION
Kresten requested us to clean up the section about Privately hosted panorama images to avoid misunderstandings. Most of the information can be found in the link below the matrix.