### PR TITLE
fixing typos in iOS map-styling

### DIFF
--- a/collections/_ios/v3/map-styling/index.md
+++ b/collections/_ios/v3/map-styling/index.md
@@ -10,24 +10,24 @@ permalink: /ios/v3/map-styling/
 
 {% include toc.md %}
 
-There are 2 ways to change the appearance of the map content in MapsIndoors and Google Maps.
+There are two ways to change the appearance of the map content in MapsIndoors and Google Maps.
 
 * Using Display Rules
 * Using Google Maps styling
 
-Each have its own purpose which will be explained below.
+Each has its own purpose which will be explained below.
 
 ## Style the Map using Display Rules
 
-In the [MapsIndoors CMS](https://cms.mapsindoors.com/types) you can set display settings for the different types of locations in your MapsIndoors content. The changes you make in the CMS will take effect whenever you app reboots or when you call `MapsIndoors.synchroniseContent()` within the app session.
+In the [MapsIndoors CMS](https://cms.mapsindoors.com/types) you can set display settings for the different types of locations in your MapsIndoors content. The changes you make in the CMS will take effect whenever your app reboots or when you call `MapsIndoors.synchroniseContent()` within the app session.
 
-In some cases, you may also want to programmatically set display settings that defines when and how to show a location. Display settings are defined in a Display Rule object.
+In some cases, you may also want to programmatically set display settings that define when and how to show a location. Display settings are defined in a Display Rule object.
 
 ```swift
 let myDisplayRule = MPLocationDisplayRule(name: "info", andIcon: UIImage(named : "info"), andZoomLevelOn: 17)
 ```
 
-You can set display settings programatically in 3 ways:
+You can set display settings programatically in three ways:
 
 * Set a Display Rule for a type of Location
 * Set a Display Rule for a single specific Location
@@ -35,7 +35,7 @@ You can set display settings programatically in 3 ways:
 
 ### Setting Display Rule for a Type
 
-To set new display rules for a type of Location, you need to know the types of Locations in your Location dataset, so you may look these up in the CMS. The types can also be retrieved in code with `MPSolutionsProvider().getSolution()`. The type objects can be read from `mySolution.types`. The display rule name corresponds to the Location Type we want the rule to apply for. So in order to style a specific type of Locations differently, just put in the type name as the Display Rule name.
+To set new display rules for a type of Location, you need to know the types of Locations in your Location dataset, so you may look these up in the CMS. The types can also be retrieved in code with `MPSolutionsProvider().getSolution()`. The type objects can be read from `mySolution.types`. The display rule name corresponds to the Location Type we want the rule to apply for. So in order to style a specific type of Location differently, just put in the type name as the Display Rule name.
 
 ```swift
 myMapControl.setDisplayRule(MPLocationDisplayRule(name: "info", andIcon: UIImage(named : "info"), andZoomLevelOn: 17))
@@ -69,7 +69,7 @@ let myDisplayRule = MPLocationDisplayRule.init(name: nil, andIcon: myImage, andZ
 myMapControl.setDisplayRule(myDisplayRule, for: myLocations)
 ```
 
-Setting a display rule for specific locations will *not* persist the new display rule for that type throughout the whole app session and across instances of `MPMapControl`. In other words, as soon as your instance of `MPMapControl` is deallocated, the overridden display rules for specific locations will reset to its original display rule.
+Setting a display rule for specific locations will *not* persist the new display rule for that type throughout the whole app session and across instances of `MPMapControl`. In other words, as soon as your instance of `MPMapControl` is deallocated, the overridden display rules for specific locations will reset to their original display rule.
 
 ## Style the Map using Google Maps Styling
 


### PR DESCRIPTION
Found a few small typos in the map-styling page. Really helpful page btw.